### PR TITLE
Fix incorrect regular expressions and timezones

### DIFF
--- a/python/lsst/ctrl/stats/records/evicted.py
+++ b/python/lsst/ctrl/stats/records/evicted.py
@@ -82,7 +82,7 @@ class Evicted(Record):
         # bytes received during the run
         self.runBytesReceived = int(self.extract(pat, lines[5], "bytes"))
 
-        pat = r"Partitionable Resources :\s+Usage\s+\Request\s+Allocated$"
+        pat = r"Partitionable Resources :\s+Usage\s+Request\s+Allocated$"
 
         # disk usage
         self.diskUsage = None

--- a/python/lsst/ctrl/stats/records/terminated.py
+++ b/python/lsst/ctrl/stats/records/terminated.py
@@ -102,7 +102,7 @@ class Terminated(Record):
         # total bytes received by job
         self.totalBytesReceived = int(self.extract(pat, lines[9], "bytes"))
 
-        pat = r"Partitionable Resources :\s+Usage\s+\Request\s+Allocated$"
+        pat = r"Partitionable Resources :\s+Usage\s+Request\s+Allocated$"
 
         # disk usage
         self.diskUsage = None

--- a/tests/helper/tolocal.py
+++ b/tests/helper/tolocal.py
@@ -1,0 +1,8 @@
+from dateutil import parser, tz
+
+def tolocal(dateVal):
+    dt = parser.parse(dateVal)
+    dt = dt.replace(tzinfo=tz.tzlocal())
+    stamp = dt.strftime('%Y-%m-%d %H:%M:%S%z')
+    return stamp
+

--- a/tests/testClassifier.py
+++ b/tests/testClassifier.py
@@ -25,14 +25,15 @@ from builtins import str
 import os
 import unittest
 import lsst.utils.tests
-from datetime import date
+import datetime
 import lsst.ctrl.stats.records as recordslib
 from lsst.ctrl.stats.reader import Reader
 from lsst.ctrl.stats.classifier import Classifier
+from helper.tolocal import tolocal
+
 
 def setup_module(module):
     lsst.utils.tests.init()
-
 
 class TestClassifier(lsst.utils.tests.TestCase):
 
@@ -52,10 +53,10 @@ class TestClassifier(lsst.utils.tests.TestCase):
         rec = entries[0]
         self.assertEqual(rec.condorId, "063.000.000")
         self.assertEqual(rec.dagNode, "A2")
-        self.assertEqual(rec.submitTime, "2016-10-17 19:59:57")
+        self.assertEqual(rec.submitTime, tolocal("2016-10-17 19:59:57"))
         self.assertEqual(rec.executionHost, "141.142.225.136:41156")
-        self.assertEqual(rec.executionStartTime, "2016-10-17 20:00:04")
-        self.assertEqual(rec.executionStopTime, "2016-10-17 20:00:14")
+        self.assertEqual(rec.executionStartTime, tolocal("2016-10-17 20:00:04"))
+        self.assertEqual(rec.executionStopTime, tolocal("2016-10-17 20:00:14"))
         self.assertEqual(rec.updateImageSize, 414300)
         self.assertEqual(rec.updateMemoryUsageMb, 81)
         self.assertEqual(rec.updateResidentSetSizeKb, 81996)
@@ -67,7 +68,7 @@ class TestClassifier(lsst.utils.tests.TestCase):
         self.assertEqual(rec.finalMemoryRequestMb, 81)
         self.assertEqual(rec.bytesSent, 25595)
         self.assertEqual(rec.bytesReceived, 1449)
-        self.assertEqual(rec.terminationTime, "2016-10-17 20:00:14")
+        self.assertEqual(rec.terminationTime, tolocal("2016-10-17 20:00:14"))
         self.assertEqual(rec.terminationCode, recordslib.terminated.eventCode)
 
     def test2(self):
@@ -77,7 +78,7 @@ class TestClassifier(lsst.utils.tests.TestCase):
         classifier = Classifier()
         self.assertIn("063.000.000", self.records)
         entries, total, updates = classifier.classify(self.records["063.000.000"])
-        self.assertEqual(total.firstSubmitTime, "2016-10-17 19:59:57")
+        self.assertEqual(total.firstSubmitTime, tolocal("2016-10-17 19:59:57"))
         self.assertEqual(total.totalBytesSent, 25595)
         self.assertEqual(total.totalBytesReceived, 1449)
         self.assertEqual(total.submissions, 1)

--- a/tests/testEvicted.py
+++ b/tests/testEvicted.py
@@ -26,8 +26,9 @@ import os
 import unittest
 import lsst.utils.tests
 import lsst.ctrl.stats.records as recordslib
-from datetime import date
+import datetime
 from lsst.ctrl.stats.reader import Reader
+from helper.tolocal import tolocal
 
 # This is a set of tests for HTCondor user (non-dagman) job logs for a job
 # that was evicted
@@ -35,7 +36,6 @@ from lsst.ctrl.stats.reader import Reader
 
 def setup_module(module):
     lsst.utils.tests.init()
-
 
 class TestEvicted(lsst.utils.tests.TestCase):
 
@@ -74,7 +74,7 @@ class TestEvicted(lsst.utils.tests.TestCase):
         self.assertEqual(rec.imageSize, 467532)
         self.assertEqual(rec.memoryUsageMb, 10)
         self.assertEqual(rec.residentSetSizeKb, 9856)
-        self.assertEqual(rec.timestamp, "2016-08-20 13:09:37")
+        self.assertEqual(rec.timestamp, tolocal("2016-08-20 13:09:37"))
 
     def test5(self):
         # check validity of second Updated record
@@ -93,7 +93,7 @@ class TestEvicted(lsst.utils.tests.TestCase):
         self.assertEqual(rec.memoryUsage, 41)
         self.assertEqual(rec.runBytesReceived, 0)
         self.assertEqual(rec.runBytesSent, 0)
-        self.assertEqual(rec.timestamp, "2016-08-20 13:12:55")
+        self.assertEqual(rec.timestamp, tolocal("2016-08-20 13:12:55"))
         self.assertEqual(rec.userRunLocalUsage, 0)
         self.assertEqual(rec.userRunRemoteUsage, 0)
 
@@ -102,7 +102,7 @@ class TestEvicted(lsst.utils.tests.TestCase):
         self.assertIn("244585.000.000", self.records)
         rec = self.records["244585.000.000"][5]
         self.assertEqual(rec.__class__.__name__, "Aborted")
-        self.assertEqual(rec.timestamp, "2016-08-20 13:12:55")
+        self.assertEqual(rec.timestamp, tolocal("2016-08-20 13:12:55"))
         self.assertEqual(rec.reason, "via condor_rm (by user srp)")
 
 

--- a/tests/testReader.py
+++ b/tests/testReader.py
@@ -26,13 +26,13 @@ import os
 import unittest
 import lsst.utils.tests
 import lsst.ctrl.stats.records as recordslib
-from datetime import date
+import datetime
 from lsst.ctrl.stats.reader import Reader
+from helper.tolocal import tolocal
 
 
 def setup_module(module):
     lsst.utils.tests.init()
-
 
 class TestReader(lsst.utils.tests.TestCase):
 
@@ -72,7 +72,7 @@ class TestReader(lsst.utils.tests.TestCase):
         self.assertEqual(rec.imageSize, 272192)
         self.assertEqual(rec.memoryUsageMb, 40)
         self.assertEqual(rec.residentSetSizeKb, 40640)
-        self.assertEqual(rec.timestamp, "2016-10-17 20:00:07")
+        self.assertEqual(rec.timestamp, tolocal("2016-10-17 20:00:07"))
 
     def test5(self):
         # check validity of second Updated record
@@ -95,7 +95,7 @@ class TestReader(lsst.utils.tests.TestCase):
         self.assertEqual(rec.sysRunRemoteUsage, 1)
         self.assertEqual(rec.sysTotalLocalUsage, 0)
         self.assertEqual(rec.sysTotalRemoteUsage, 1)
-        self.assertEqual(rec.timestamp, "2016-10-17 20:00:14")
+        self.assertEqual(rec.timestamp, tolocal("2016-10-17 20:00:14"))
         self.assertEqual(rec.totalBytesReceived, 1449)
         self.assertEqual(rec.totalBytesSent, 25594)
         self.assertEqual(rec.userRunLocalUsage, 0)

--- a/tests/testTerminated.py
+++ b/tests/testTerminated.py
@@ -26,7 +26,8 @@ import os
 import unittest
 import lsst.utils.tests
 import lsst.ctrl.stats.records as recordslib
-from datetime import date
+import datetime
+from helper.tolocal import tolocal
 from lsst.ctrl.stats.reader import Reader
 
 # This is a set of tests for HTCondor user (non-dagman) job logs, for
@@ -35,7 +36,6 @@ from lsst.ctrl.stats.reader import Reader
 
 def setup_module(module):
     lsst.utils.tests.init()
-
 
 class TestTerminated(lsst.utils.tests.TestCase):
 
@@ -74,7 +74,7 @@ class TestTerminated(lsst.utils.tests.TestCase):
         self.assertEqual(rec.imageSize, 467144)
         self.assertEqual(rec.memoryUsageMb, 10)
         self.assertEqual(rec.residentSetSizeKb, 9360)
-        self.assertEqual(rec.timestamp, "2016-08-21 10:27:31")
+        self.assertEqual(rec.timestamp, tolocal("2016-08-21 10:27:31"))
 
     def test5(self):
         # check validity of second Updated record
@@ -97,7 +97,7 @@ class TestTerminated(lsst.utils.tests.TestCase):
         self.assertEqual(rec.sysRunRemoteUsage, 0)
         self.assertEqual(rec.sysTotalLocalUsage, 0)
         self.assertEqual(rec.sysTotalRemoteUsage, 0)
-        self.assertEqual(rec.timestamp, "2016-08-21 10:29:43")
+        self.assertEqual(rec.timestamp, tolocal("2016-08-21 10:29:43"))
         self.assertEqual(rec.totalBytesReceived, 0)
         self.assertEqual(rec.totalBytesSent, 0)
         self.assertEqual(rec.userRunLocalUsage, 0)

--- a/tests/testYearWrap.py
+++ b/tests/testYearWrap.py
@@ -26,13 +26,14 @@ import os
 import unittest
 import lsst.utils.tests
 import lsst.ctrl.stats.records as recordslib
-from datetime import date
+import datetime
+from dateutil import tz, parser
 from lsst.ctrl.stats.reader import Reader
+from helper.tolocal import tolocal
 
 
 def setup_module(module):
     lsst.utils.tests.init()
-
 
 class TestYearWrap(lsst.utils.tests.TestCase):
 
@@ -52,49 +53,49 @@ class TestYearWrap(lsst.utils.tests.TestCase):
         self.assertIn("061.000.000", self.records)
         rec = self.records["061.000.000"][0]
         self.assertEqual(rec.__class__.__name__, "Submitted")
-        self.assertEqual(rec.timestamp, "2016-12-31 19:59:53")
+        self.assertEqual(rec.timestamp, tolocal("2016-12-31 19:59:53"))
         rec = self.records["061.000.000"][1]
         self.assertEqual(rec.__class__.__name__, "Executing")
-        self.assertEqual(rec.timestamp, "2016-12-31 19:59:55")
+        self.assertEqual(rec.timestamp, tolocal("2016-12-31 19:59:55"))
         rec = self.records["061.000.000"][2]
         self.assertEqual(rec.__class__.__name__, "Terminated")
-        self.assertEqual(rec.timestamp, "2016-12-31 19:59:55")
+        self.assertEqual(rec.timestamp, tolocal("2016-12-31 19:59:55"))
 
     def test3(self):
         # check validity of Executing record
         self.assertIn("062.000.000", self.records)
         rec = self.records["062.000.000"][1]
         self.assertEqual(rec.__class__.__name__, "Executing")
-        self.assertEqual(rec.timestamp, "2016-12-31 19:59:58")
+        self.assertEqual(rec.timestamp, tolocal("2016-12-31 19:59:58"))
 
         rec = self.records["062.000.000"][2]
         self.assertEqual(rec.__class__.__name__, "Updated")
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:07")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:07"))
 
         rec = self.records["062.000.000"][4]
         self.assertEqual(rec.__class__.__name__, "Terminated")
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:14")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:14"))
 
     def test4(self):
         # check validity of Executing record
         self.assertIn("063.000.000", self.records)
         rec = self.records["063.000.000"][1]
         self.assertEqual(rec.__class__.__name__, "Executing")
-        self.assertEqual(rec.timestamp, "2016-12-31 20:00:04")
+        self.assertEqual(rec.timestamp, tolocal("2016-12-31 20:00:04"))
 
         rec = self.records["063.000.000"][3]
         self.assertEqual(rec.__class__.__name__, "Terminated")
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:14")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:14"))
 
     def test7(self):
         # check validity of post record
         self.assertIn("065.000.000", self.records)
         rec = self.records["065.000.000"][0]
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:16")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:16"))
         rec = self.records["065.000.000"][1]
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:17")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:17"))
         rec = self.records["065.000.000"][2]
-        self.assertEqual(rec.timestamp, "2017-01-01 20:00:19")
+        self.assertEqual(rec.timestamp, tolocal("2017-01-01 20:00:19"))
 
 class ReaderMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testfiles/year.metrics
+++ b/tests/testfiles/year.metrics
@@ -6,7 +6,7 @@
     "type":"metrics",
     "wf_uuid":"",
     "root_wf_uuid":"",
-    "start_time":1483214397.254,
+    "start_time":1483214390.254,
     "end_time":1483300814.801,
     "duration":108.547,
     "exitcode":2,


### PR DESCRIPTION
Stricter regular expression parsing in python 3.6 uncovered a latent
issue in two expressions.  \R should have been \s+R